### PR TITLE
내 티켓 몰아보기 API 작업

### DIFF
--- a/src/main/java/com/yoyakso/comket/project/service/ProjectService.java
+++ b/src/main/java/com/yoyakso/comket/project/service/ProjectService.java
@@ -12,6 +12,7 @@ import com.yoyakso.comket.project.dto.ProjectMemberResponse;
 import com.yoyakso.comket.project.dto.ProjectMemberUpdateRequest;
 import com.yoyakso.comket.project.entity.Project;
 import com.yoyakso.comket.project.enums.ProjectState;
+import com.yoyakso.comket.workspace.entity.Workspace;
 
 @Service
 public interface ProjectService {
@@ -45,6 +46,8 @@ public interface ProjectService {
 		ProjectMemberInviteRequest request);
 
 	Project getProjectByProjectName(String projectName);
+
+	List<Project> getProjectsByWorkspaceAndMember(Workspace workspace, Member member);
 
 	void validateProjectAccess(Project project, Member member, String target);
 }

--- a/src/main/java/com/yoyakso/comket/project/service/ProjectServiceImpl.java
+++ b/src/main/java/com/yoyakso/comket/project/service/ProjectServiceImpl.java
@@ -235,7 +235,7 @@ public class ProjectServiceImpl implements ProjectService {
 		List<Project> projects = (positionType.equals("ADMIN") || positionType.equals("OWNER"))
 			? projectRepository.findAllByWorkspaceAndState(workSpace, ProjectState.ACTIVE)
 			: projectMemberService.getProjectListByMemberAndWorkspace(member, workSpace);
-		
+
 		return projects.stream()
 			.map(project -> {
 				String profileFileUrl = project.getProfileFile() != null
@@ -443,6 +443,11 @@ public class ProjectServiceImpl implements ProjectService {
 		if (projectMember == null || projectMember.getState() != ProjectMemberState.ACTIVE) {
 			throw new CustomException("PROJECT_ACCESS_FAILED", target + "에 대한 프로젝트에 대한 권한이 없습니다.");
 		}
+	}
+
+	@Override
+	public List<Project> getProjectsByWorkspaceAndMember(Workspace workspace, Member member) {
+		return projectMemberService.getProjectListByMemberAndWorkspace(member, workspace);
 	}
 
 	// ---private methods---

--- a/src/main/java/com/yoyakso/comket/ticket/controller/TicketController.java
+++ b/src/main/java/com/yoyakso/comket/ticket/controller/TicketController.java
@@ -22,6 +22,7 @@ import com.yoyakso.comket.ticket.dto.request.TicketStateUpdateRequest;
 import com.yoyakso.comket.ticket.dto.request.TicketTypeUpdateRequest;
 import com.yoyakso.comket.ticket.dto.request.TicketUpdateRequest;
 import com.yoyakso.comket.ticket.dto.response.TicketInfoResponse;
+import com.yoyakso.comket.ticket.dto.response.TicketProjectInfoResponse;
 import com.yoyakso.comket.ticket.entity.Ticket;
 import com.yoyakso.comket.ticket.mapper.TicketMapper;
 import com.yoyakso.comket.ticket.service.TicketService;
@@ -57,6 +58,18 @@ public class TicketController {
 		List<Ticket> tickets = ticketService.getTickets(projectName, member);
 		return ResponseEntity.ok(tickets.stream()
 			.map(ticketMapper::toResponse)
+			.toList());
+	}
+
+	// 내 티켓 몰아보기 조회
+	@GetMapping("/workspace")
+	public ResponseEntity<List<TicketProjectInfoResponse>> getTicketWorkspaces(
+		@RequestParam("workspace_name") String workspaceName
+	) {
+		Member member = memberService.getAuthenticatedMember();
+		List<Ticket> tickets = ticketService.getTicketsByWorkspace(workspaceName, member);
+		return ResponseEntity.ok(tickets.stream()
+			.map(ticketMapper::toWorkspaceResponse)
 			.toList());
 	}
 

--- a/src/main/java/com/yoyakso/comket/ticket/dto/response/TicketProjectInfoResponse.java
+++ b/src/main/java/com/yoyakso/comket/ticket/dto/response/TicketProjectInfoResponse.java
@@ -1,0 +1,49 @@
+package com.yoyakso.comket.ticket.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yoyakso.comket.project.dto.ProjectMemberResponse;
+import com.yoyakso.comket.ticket.enums.TicketPriority;
+import com.yoyakso.comket.ticket.enums.TicketState;
+import com.yoyakso.comket.ticket.enums.TicketType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TicketProjectInfoResponse {
+	private Long id;
+	@JsonProperty("ticket_name")
+	private String name;
+	private String description;
+	@JsonProperty("ticket_type")
+	private TicketType type;
+	@JsonProperty("parent_ticket_id")
+	private Long parentTicketId;
+	@JsonProperty("ticket_priority")
+	private TicketPriority priority;
+	@JsonProperty("ticket_state")
+	private TicketState state;
+	@JsonProperty("start_date")
+	private LocalDate startDate;
+	@JsonProperty("end_date")
+	private LocalDate endDate;
+	@JsonProperty("created_at")
+	private LocalDateTime createdAt;
+	@JsonProperty("updated_at")
+	private LocalDateTime updatedAt;
+	@JsonProperty("assignee_member")
+	private ProjectMemberResponse assigneeMember;
+	@JsonProperty("creator_member")
+	private ProjectMemberResponse creatorMember;
+	@JsonProperty("sub_ticket_count")
+	private Long subTicketCount;
+	@JsonProperty("additional_info")
+	private Map<String, Object> additionalInfo;
+	@JsonProperty("project_name")
+	private String projectName;
+}

--- a/src/main/java/com/yoyakso/comket/ticket/mapper/TicketMapper.java
+++ b/src/main/java/com/yoyakso/comket/ticket/mapper/TicketMapper.java
@@ -11,6 +11,7 @@ import com.yoyakso.comket.projectMember.service.ProjectMemberService;
 import com.yoyakso.comket.ticket.dto.request.TicketCreateRequest;
 import com.yoyakso.comket.ticket.dto.request.TicketUpdateRequest;
 import com.yoyakso.comket.ticket.dto.response.TicketInfoResponse;
+import com.yoyakso.comket.ticket.dto.response.TicketProjectInfoResponse;
 import com.yoyakso.comket.ticket.entity.Ticket;
 
 @Component
@@ -78,4 +79,27 @@ public class TicketMapper {
 		updateField(ticket::setAdditionalInfo, request.getAdditionalInfo(), true, null, null); // 추가 정보 처리
 	}
 
+	public TicketProjectInfoResponse toWorkspaceResponse(Ticket ticket) {
+		return TicketProjectInfoResponse.builder()
+			.id(ticket.getId())
+			.name(ticket.getName())
+			.description(ticket.getDescription())
+			.type(ticket.getType())
+			.priority(ticket.getPriority())
+			.state(ticket.getState())
+			.startDate(ticket.getStartDate())
+			.endDate(ticket.getEndDate())
+			.createdAt(ticket.getCreatedAt())
+			.updatedAt(ticket.getUpdatedAt())
+			.assigneeMember(
+				ticket.getAssignee() != null ?
+					projectMemberService.buildProjectMemberInfoResponse(ticket.getProject(), ticket.getAssignee()) :
+					null)
+			.creatorMember(
+				projectMemberService.buildProjectMemberInfoResponse(ticket.getProject(), ticket.getCreator()))
+			.parentTicketId(ticket.getParentTicket() != null ? ticket.getParentTicket().getId() : null)
+			.subTicketCount(ticket.getSubTicketCount())
+			.additionalInfo(ticket.getAdditionalInfo()) // 추가 정보 매핑
+			.build();
+	}
 }

--- a/src/main/java/com/yoyakso/comket/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/yoyakso/comket/ticket/repository/TicketRepository.java
@@ -36,4 +36,6 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
 	);
 
 	Long countByParentTicket(Ticket t);
+
+	List<Ticket> findByProjectInAndIsDeletedFalse(List<Project> projects);
 }

--- a/src/main/java/com/yoyakso/comket/ticket/service/TicketService.java
+++ b/src/main/java/com/yoyakso/comket/ticket/service/TicketService.java
@@ -23,6 +23,8 @@ import com.yoyakso.comket.ticket.dto.response.TicketInfoResponse;
 import com.yoyakso.comket.ticket.entity.Ticket;
 import com.yoyakso.comket.ticket.mapper.TicketMapper;
 import com.yoyakso.comket.ticket.repository.TicketRepository;
+import com.yoyakso.comket.workspace.entity.Workspace;
+import com.yoyakso.comket.workspace.service.WorkspaceService;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ public class TicketService {
 	private final ProjectService projectService;
 	private final TicketMapper ticketMapper;
 	private final KafkaTopicService kafkaTopicService;
+	private final WorkspaceService workspaceService;
 
 	@Transactional
 	public TicketInfoResponse createTicket(String projectName, TicketCreateRequest request,
@@ -243,6 +246,16 @@ public class TicketService {
 
 	public Long getProjectIdByTicketId(Long ticketId) {
 		return ticketRepository.findProjectIdByTicketId(ticketId);
+	}
+
+	@Transactional
+	public List<Ticket> getTicketsByWorkspace(String workspaceName, Member member) {
+		// 워크스페이스에 속한 프로젝트 목록을 가져오기
+		Workspace workspace = workspaceService.getWorkspaceByWorkspaceName(workspaceName, member);
+		// 해당 워크스페이스 내의 프로젝트에 속한 티켓 목록을 가져오기
+		List<Project> projectList = projectService.getProjectsByWorkspaceAndMember(workspace, member);
+
+		return ticketRepository.findByProjectInAndIsDeletedFalse(projectList);
 	}
 
 	// ------private------

--- a/src/main/java/com/yoyakso/comket/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/yoyakso/comket/workspace/service/WorkspaceService.java
@@ -57,6 +57,14 @@ public class WorkspaceService {
 		return workspace;
 	}
 
+	public Workspace getWorkspaceByWorkspaceName(String workspaceName, Member member) {
+		Workspace workspace = workspaceRepository.findByName(workspaceName)
+			.filter(ws -> ws.getState().equals(WorkspaceState.ACTIVE))
+			.orElseThrow(() -> new CustomException("WORKSPACE_NOT_FOUND", "워크스페이스 정보를 찾을 수 없습니다."));
+		validateWorkspaceAccess(workspace, member);
+		return workspace;
+	}
+
 	public List<Workspace> getAllWorkspaces() {
 		return workspaceRepository.findAll();
 	}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

연관된 이슈 번호를 작성해주세요.

## 💯 PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 단순 코드 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 관련 변경
- [ ] 빌드, 패키지 매니저 수정
- [ ] 파일, 폴더 수정/삭제
- [ ] 버그 수정
- [ ] 핫픽스
- [ ] 배포

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요(스크린샷 첨부 가능)
1. 내 티켓 몰아보기용 API 추가
  - Workspace에 대한 소속 검증은 했고, Project 소속 검증은 뺏습니다. (속한 티켓이 있다는 것 자체가 project에 속한 것이기 때문)
2. Postman 내 티켓 몰아보기 API 예시 추가 


## 💬 요구사항 (선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
1. 추후에 리팩한다면 ProjectMapper 추가하는것도 좋을 것 같습니다(Ticket에서 Project 조회시에 ProjectInfoResponse형태로 호출해야했기 때문)
2. Builder의 함정을 하나 발견했는데, TicketProjectInfoResponse가 TicketInfoResponse에서 proejctName만 추가된 사항인데, extends형은 Builder가 지원하지 않더군요. 그래서 일단 전부 추가해줬는데, 더 개선할 방법이 있으면 말씀해주시면 감사하겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 컨벤션을 준수했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
